### PR TITLE
Fix for event unsubscribing when processing different handler on same event

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -14,23 +14,22 @@ module.exports = {
      */
     register: function (id, callback, context, options) {
         this['callbacks'] = this['callbacks'] || {};
-        if (typeof this['callbacks'][id] === 'undefined') {
-            this['callbacks'][id] = [];
-        }
+        var itemIdCounter = this['callbacksSubscriberIdCounter'] || 1;
         var exists = false;
-        var collection = this['callbacks'][id];
-        for (var index = 0, length = collection.length; index < length; index++) {
-            if (collection[index].callback === callback) {
+        var collection = this['callbacks'][id] || {};
+        _.forOwn(collection, function (collectionItem) {
+            if (collectionItem && collectionItem.callback === callback) {
                 exists = true;
-                break;
             }
-        }
+        });
         if (!exists) {
-            this['callbacks'][id].push({
+            collection[itemIdCounter++] = {
                 callback: callback,
                 context: context || this,
                 options: (typeof options === 'object') || {}
-            });
+            };
+            this['callbacks'][id] = collection;
+            this['callbacksSubscriberIdCounter'] = itemIdCounter;
         }
         return this;
     },
@@ -53,20 +52,20 @@ module.exports = {
      */
     dispatch: function (id, data) {
         if (this['callbacks'] && this['callbacks'][id]) {
+
             var collection = this['callbacks'][id];
-            var collectionItem;
             var itemsToDelete = [];
-            for (var index = 0, length = collection.length; index < length; index++) {
-                collectionItem = collection[index];
-                if (typeof collectionItem.callback === 'function') {
-                    collectionItem.callback.apply(collectionItem.context, [data]);
+
+            _.forOwn(collection, function (collectionItem, collectionItemId) {
+                if (collectionItem && typeof collectionItem.callback === 'function') {
+                    collectionItem.callback.apply(collectionItem.context, data && [data]);
                     if (collectionItem.options.once) {
-                        itemsToDelete.push(index);
+                        itemsToDelete.push(collectionItemId);
                     }
                 }
-            }
-            for (var index = itemsToDelete.length - 1, finish = 0; index >= finish; index--) {
-                collection.splice(itemsToDelete[index], 1);
+            });
+            for (var index = 0, length = itemsToDelete.length; index < length; index++) {
+                delete collection[itemsToDelete[index]];
             }
         }
         return this;
@@ -79,21 +78,16 @@ module.exports = {
      */
     unregister: function (id, callback) {
         if (this['callbacks'] && this['callbacks'][id]) {
-            var callbackIndex;
             var collection = this['callbacks'][id];
-            for (var index = 0, length = collection.length; index < length; index++) {
-                if (collection[index].callback === callback) {
-                    callbackIndex = index;
-                    break;
+            _.forOwn(collection, function (collectionItem, id) {
+                if (collectionItem.callback === callback) {
+                    delete collection[id];
                 }
-            }
-            if (typeof callbackIndex !== 'undefined') {
-                collection.splice(callbackIndex, 1);
-            }
+            });
         }
         return this;
     },
-    
+
     /**
      * Provides wait for store changes feature
      * @param {object|object[]} chain

--- a/lib/utils/event-emitter.js
+++ b/lib/utils/event-emitter.js
@@ -2,6 +2,7 @@
 'use strict';
 
 module.exports = {
+
     /**
      * @param {string} id of event
      * @param {function} callback
@@ -12,23 +13,22 @@ module.exports = {
      */
     on: function (id, callback, context, options) {
         this['__events'] = this['__events'] || {};
-        if (typeof this['__events'][id] === 'undefined') {
-            this['__events'][id] = [];
-        }
+        var itemIdCounter = this['__eventsSubscriberIdCounter'] || 1;
         var exists = false;
-        var collection = this['__events'][id];
-        for (var index = 0, length = collection.length; index < length; index++) {
-            if (collection[index].callback === callback) {
+        var collection = this['__events'][id] || {};
+        _.forOwn(collection, function (collectionItem) {
+            if (collectionItem && collectionItem.callback === callback) {
                 exists = true;
-                break;
             }
-        }
+        });
         if (!exists) {
-            this['__events'][id].push({
+            collection[itemIdCounter++] = {
                 callback: callback,
                 context: context || this,
                 options: (typeof options === 'object') || {}
-            });
+            };
+            this['__events'][id] = collection;
+            this['__eventsSubscriberIdCounter'] = itemIdCounter;
         }
         return this;
     },
@@ -37,8 +37,6 @@ module.exports = {
      * @param {string} id of event
      * @param {function} callback
      * @param {object} [context]
-     * @param {object} [options]
-     * @param {boolean} [options.once=false]
      * @returns {object} this
      */
     once: function (id, callback, context) {
@@ -47,26 +45,24 @@ module.exports = {
 
     /**
      * @param {string} id of event
-     * @param {object} data to push
      * @param {object} [params] for callback
      * @returns {object} this
      */
     emit: function (id, params) {
         if (this['__events'] && this['__events'][id]) {
             var collection = this['__events'][id];
-            var collectionItem;
             var itemsToDelete = [];
-            for (var index = 0, length = collection.length; index < length; index++) {
-                collectionItem = collection[index];
-                if (typeof collectionItem.callback === 'function') {
+
+            _.forOwn(collection, function (collectionItem, collectionItemId) {
+                if (collectionItem && typeof collectionItem.callback === 'function') {
                     collectionItem.callback.apply(collectionItem.context, params && [params]);
                     if (collectionItem.options.once) {
-                        itemsToDelete.push(index);
+                        itemsToDelete.push(collectionItemId);
                     }
                 }
-            }
+            });
             for (var index = 0, length = itemsToDelete.length; index < length; index++) {
-                collection.splice(itemsToDelete[index], 1);
+                delete collection[itemsToDelete[index]];
             }
         }
         return this;
@@ -79,17 +75,12 @@ module.exports = {
      */
     off: function (id, callback) {
         if (this['__events'] && this['__events'][id]) {
-            var callbackIndex;
             var collection = this['__events'][id];
-            for (var index = 0, length = collection.length; index < length; index++) {
-                if (collection[index].callback === callback) {
-                    callbackIndex = index;
-                    break;
+            _.forOwn(collection, function (collectionItem, id) {
+                if (collectionItem.callback === callback) {
+                    delete collection[id];
                 }
-            }
-            if (typeof callbackIndex !== 'undefined') {
-                collection.splice(callbackIndex, 1);
-            }
+            });
         }
         return this;
     }


### PR DESCRIPTION
I replaced subscribers array with objects and incremental keys. 
When subscribing we generating new incremental id and write handler info there. 
When unsubscribing we delete hanler info from there.
This prevents situations where subscriber array spliced in process of some handler in this array are being processed. Which resulting in potential loss of next subscriber and runtime exception (acessing out of array bounds).
